### PR TITLE
Fixup compile commands, add makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,17 @@
+.PHONY: all
+all: c++ rust zig-safe zig-fast c
+
+c: c.c
+	clang -stdlib=libgcc -O3 $< -o $@
+
+c++: c++.cpp
+	clang++ -stdlib=libstdc++ -O3 $< -o $@
+
+rust: rust.rs
+	rustc -C opt-level=3 $<
+
+zig-safe: zig.zig
+	zig build-exe $< -target x86_64-linux -O ReleaseSafe --name $@
+
+zig-fast: zig.zig
+	zig build-exe $< -target x86_64-linux -O ReleaseFast --name $@

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,12 @@
+TARGETS = c++ rust zig-safe zig-fast c
+RUNS ?= 3
+
 .PHONY: all
-all: c++ rust zig-safe zig-fast c
+all: $(TARGETS)
+
+.PHONY: benchmark
+benchmark: all
+	hyperfine -r$(RUNS) $(foreach TARGET,$(TARGETS),./$(TARGET))
 
 c: c.c
 	clang -stdlib=libgcc -O3 $< -o $@

--- a/readme.md
+++ b/readme.md
@@ -37,7 +37,7 @@ cccccccc;.:odl:.;cccccccccccccc:,.       CPU: 11th Gen Intel i5-11400H (12) @ 4.
 Now, these are the results:
 
 ```
-$ clang++ -stdlib=libstdc++ -O3 c++.cpp
+$ clang++ -stdlib=libstdc++ -O3 c++.cpp -o c++
 $ time ./c++ 
 The result is 9999999999
 real    1m59.314s
@@ -55,8 +55,8 @@ sys     0m0.002s
 ```
 
 ```
-$ zig build-exe zig.zig -target x86_64-linux -O ReleaseSafe
-$ time ./zig
+$ zig build-exe zig.zig -target x86_64-linux -O ReleaseSafe --name zig-safe
+$ time ./zig-safe
 The result is 9999999999
 
 real    1m38.193s
@@ -65,8 +65,8 @@ sys     0m0.003s
 ```
 
 ```
-$ zig build-exe zig.zig -target x86_64-linux -O ReleaseFast
-$ time ./zig
+$ zig build-exe zig.zig -target x86_64-linux -O ReleaseFast --name zig-fast
+$ time ./zig-fast
 The result is 9999999999
 
 real    1m56.232s
@@ -75,7 +75,7 @@ sys     0m0.003s
 ```
 
 ```
-$ clang -stdlib=libgcc -O3 c.c
+$ clang -stdlib=libgcc -O3 c.c -o c
 $ time ./c
 The result is 9999999999
 real    1m58.715s


### PR DESCRIPTION
A few of the compile commands in the readme don't actually produce the names expected (rather `a.out`), and the zig ones clobber each-other. These commands should fix that up. It also adds a Makefile for convenience that can run any or all of the builds automatically. Lastly there is a target that uses `hyperfine` to actually run the benchmarks in a much more useful way that includes multiple passes of each to avoid system jitter, bad results from some other process that happened to interfere more with one run than another, etc. It also does a bunch of the math to show you relative results.

For example to build everything and then benchmark them all with 2 runs each:

```console
$ make benchmark RUNS=2
```
